### PR TITLE
Fix avulse bug

### DIFF
--- a/avulse.py
+++ b/avulse.py
@@ -10,7 +10,41 @@ from avulsion_utils import (find_point_in_path, channel_is_superelevated,
                             find_path_length)
 
 
-def avulse_to_new_path(z, old, new, sea_level, channel_depth, avulsion_type, dx=1., dy=1.,):
+def avulse_to_new_path(z, old, new, sea_level, channel_depth, avulsion_type,
+                       dx=1., dy=1.,):
+    """Avulse the river to a new path.
+
+    Given two river paths, *old* and *new*, avulse the river to a new river
+    path. If the end point of the new path is contained in the old river
+    path, the resulting path is the new path up until this point and then
+    the old path. Otherwise, the resulting path is the new river path and
+    will be downcut.
+
+    Parameters
+    ----------
+    z : ndarray
+        2D array of elevations.
+    old : tuple of array_like
+        Tuple of i and j indices (into *z*) for the old path.
+    new : tuple of array_like
+        Tuple of i and j indices (into *z*) for the new path.
+    sea_level : float
+        Elevation of sea level.
+    channel_depth : float
+        Depth of the channel.
+    avulsion_type : {0, 1, 2, 3}
+        The type of the avulsion.
+    dx : float, optional
+        Spacing of columns of *z*.
+    dy : float, optional
+        Spacing of rows of *z*.
+
+    Returns
+    -------
+    tuple
+        Tuple of the new river path (as i, j indices) and the, possibly
+        changed, avulsion type.
+    """
     old_i, old_j = old
     new_i, new_j = new
     # sets avulsion to be regional, may be updated again below (if local)

--- a/avulsion_utils.py
+++ b/avulsion_utils.py
@@ -90,7 +90,29 @@ def find_path_length(path, dx=1., dy=1.):
 
 
 def find_point_in_path(path, sub):
+    """Find a point in a path.
+
+    Parameters
+    ----------
+    path : tuple of array_like
+        Tuple of arrays of int that represent indices into a matrix.
+    sub : tuple in int
+        Indices to search *path* for.
+
+    Returns
+    -------
+    int or None
+        Index into *path* if the indices are found. Otherwise, ``None``.
+
+    Examples
+    --------
+    >>> path = ((0, 1, 4, 6, 5), (3, 1, 7, 8, 10))
+    >>> find_point_in_path(path, (4, 7))
+    2
+    >>> find_point_in_path(path, (99, 2)) is None
+    True
+    """
     try:
-        return zip(path).index(sub)
+        return zip(*path).index(sub)
     except ValueError:
         return None

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+import sys
+
+import numpy as np
+
+
+def plot_elevation(avulsion):
+    import matplotlib.pyplot as plt
+
+    z = avulsion.get_value('land_surface__elevation')
+
+    plt.imshow(z, origin='lower', cmap='terrain')
+    plt.colorbar().ax.set_label('Elevation (m)')
+    plt.show()
+
+
+def main():
+    import argparse
+    from avulsion_bmi import BmiRiverModule
+
+    parser = argparse.ArgumentParser('Run the avulsion model')
+    parser.add_argument('file', help='YAML-formatted parameters file')
+    parser.add_argument('--days', type=int, default=0,
+                        help='Run model for DAYS')
+    parser.add_argument('--years', type=int, default=0,
+                        help='Run model for YEARS')
+    parser.add_argument('--plot', action='store_true',
+                        help='Plot final elevations')
+
+    args = parser.parse_args()
+
+    np.random.seed(1945)
+
+    avulsion = BmiRiverModule()
+    avulsion.initialize(args.file)
+
+    n_steps = int((args.days + args.years * 365.) / avulsion.get_time_step())
+    for _ in xrange(n_steps):
+        avulsion.update()
+
+    if args.plot:
+        plot_elevation(avulsion)
+
+    z = avulsion.get_value('land_surface__elevation')
+    np.savetxt(sys.stdout, z)
+
+    avulsion.finalize()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request attempts to fix the bug that @katmratliff reported:

> If the river is superelevated and an avulsion is triggered, but the "mouth" of the new steepest
> descent path falls along the prior river course, then no new downcutting should occur.
> Looking at how you've changed it, I haven't been able to figure out what's not working,
> but I have noticed that the river course will shorten along its prior path and downcut, so
> something's not quite right.

Changes:
- Fixed a bug in the `find_point_in_path` function in `avulsion_utils.py` where the point was never found in the path, even if it was really there.
- Added a couple docstrings and doctests.

I don't know if this fixes the larger problem but it was definitely a bug that would impact the reported problem.
