### PR TITLE
Implement get_grid_node_count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_install:
 install:
 - pip install .
 script:
+- pip install -r requirements-testing.txt
 - rafem --version
 - rafem --help
 - rafem show --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,5 @@ script:
 - rafem plot --help
 - rafem show rafem
 - mkdir example && rafem --cd example setup run
+- mkdir bmi-test && rafem --cd bmi-test setup && bmi-test rafem:BmiRiverModule --config-file=rafem.yaml --root-dir=bmi-test
 after_success: coveralls

--- a/rafem/riverbmi.py
+++ b/rafem/riverbmi.py
@@ -163,12 +163,6 @@ class BmiRiverModule(Bmi):
 
         return shape
 
-        # if out is None:
-        #     return shape
-        # else:
-        #     out[:] = shape
-        #     return out
-
     def get_grid_spacing(self, grid, spacing):
         if grid == 0:
             spacing[:] = self._model.grid_spacing
@@ -176,23 +170,12 @@ class BmiRiverModule(Bmi):
             raise KeyError(grid)
         return spacing
 
-        # if out is None:
-        #     return self._model.grid_spacing
-        # else:
-        #     out[:] = self._model.grid_spacing
-        #     return out
-
     def get_grid_origin(self, grid, origin):
         if grid == 0:
             origin[:] = (0.0, 0.0)
         else:
             raise KeyError(grid)
         return origin
-        # if out is None:
-        #     return origin
-        # else:
-        #     out[:] = origin
-        #     return out
 
     def get_grid_type(self, grid):
         if grid == 0:
@@ -263,7 +246,14 @@ class BmiRiverModule(Bmi):
         return "d"
 
     def get_grid_node_count(self, grid):
-        raise NotImplementedError("get_grid_node_count")
+        if grid == 0:
+            return int(np.prod(self._model.grid_shape))
+        elif grid == 1:
+            return len(self._model.river_x_coordinates)
+        elif grid == 2:
+            return 1
+        else:
+            raise KeyError(grid)
 
     def get_grid_edge_count(self, grid):
         raise NotImplementedError("get_grid_edge_count")

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,4 @@
+bmi-tester
 pytest
 pytest-benchmark
 pytest-cov


### PR DESCRIPTION
This pull request fixes a bug found by @hunjhunj that causes the following,
```python
 NotImplementedError: get_grid_node_count
```
I've implemented *get_grid_node_count* (for backward compatibility I've still kept the old *get_grid_size*, which does that same thing). I've also added a test of the BMI to our CI on Travis so that we may be able to find these sorts of issues sooner.